### PR TITLE
Waterfall: reuse QPen instead of allocating a new one each time

### DIFF
--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -212,6 +212,9 @@ Waterfall::Waterfall(QWidget *parent) : QFrame(parent)
             m_ColorTbl[i].setRgb(255, 255*(i-250)/5, 255*(i-250)/5);
     }
 
+    for (int i = 0; i < 256; i++)
+        m_ColorPenTbl[i] = QPen(m_ColorTbl[i]);
+
     m_PeakHoldActive = false;
     m_PeakHoldValid = false;
 
@@ -1061,7 +1064,7 @@ void Waterfall::draw(bool everything)
                 // user set time span
                 for (i = xmin; i < xmax; i++)
                 {
-                    painter1.setPen(m_ColorTbl[255 - m_wfbuf[i]]);
+                    painter1.setPen(m_ColorPenTbl[255 - m_wfbuf[i]]);
                     painter1.drawPoint(i, 0);
                     m_wfbuf[i] = 255;
                 }
@@ -1070,7 +1073,7 @@ void Waterfall::draw(bool everything)
             {
                 for (i = xmin; i < xmax; i++)
                 {
-                    painter1.setPen(m_ColorTbl[255 - m_fftbuf[i]]);
+                    painter1.setPen(m_ColorPenTbl[255 - m_fftbuf[i]]);
                     painter1.drawPoint(i, 0);
                 }
             }

--- a/Waterfall.h
+++ b/Waterfall.h
@@ -125,8 +125,10 @@ public:
     {
       unsigned int i;
 
-      for (i = 0; i < 256; ++i)
+      for (i = 0; i < 256; ++i) {
         this->m_ColorTbl[i] = table[i];
+        this->m_ColorPenTbl[i] = QPen(table[i]);
+      }
 
       this->update();
     }
@@ -331,7 +333,8 @@ private:
     QPixmap     m_2DPixmap;
     QPixmap     m_OverlayPixmap;
     QPixmap     m_WaterfallPixmap;
-    QColor              m_ColorTbl[256];
+    QColor      m_ColorTbl[256];
+    QPen        m_ColorPenTbl[256];
     QSize       m_Size;
     QString     m_Str;
     QString     m_HDivText[HORZ_DIVS_MAX+1];


### PR DESCRIPTION
The watefall widget was unnecessarily allocating new QPens on the heap
every time it wanted to draw a point.  The offending stack trace was:

    libc.so.7`malloc+0x1
    libc++.so.1`operator new(unsigned long)+0x2a
    libQt5Gui.so.5.13.2`QBrush::init(QColor const&, Qt::BrushStyle)+0x126
    libQt5Gui.so.5.13.2`QPen::QPen(QColor const&)+0x47
    libQt5Gui.so.5.13.2`QPainter::setPen(QColor const&)+0x65
    libsuwidgets.so.0.1.1`Waterfall::draw(bool)+0x514
    libQt5Core.so.5.13.2`QMetaObject::activate(QObject*, int, int, void**)+0x751
    SigDigger`0x4e57a6
    SigDigger`0x4bbc9c
    libQt5Core.so.5.13.2`QObject::event(QEvent*)+0x2c8
    libQt5Widgets.so.5.13.2`QApplicationPrivate::notify_helper(QObject*, QEvent*)+0x113
    libQt5Widgets.so.5.13.2`QApplication::notify(QObject*, QEvent*)+0x26c
    libQt5Core.so.5.13.2`QCoreApplication::notifyInternal2(QObject*, QEvent*)+0xd2
    libQt5Core.so.5.13.2`QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)+0x35b
    libQt5Core.so.5.13.2`0x8024923f8
    libglib-2.0.so.0.5600.3`g_main_context_dispatch+0x147
    libglib-2.0.so.0.5600.3`0x8033d8b9a
    libglib-2.0.so.0.5600.3`g_main_context_iteration+0x64
    libQt5Core.so.5.13.2`QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)+0x66
    libQt5Core.so.5.13.2`QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)+0x1ee

Note that this was the largest heap abuser with approximately 27k
mallocs/second when replaying a 1.024 MS/s raw file.

Before the fix, the malloc size distribution during a 10 second sampling
of signal replay was (value is the malloc size rounded to powers-of-2
buckets):

           value  ------------- Distribution ------------- count
               2 |                                         0
               4 |                                         96
               8 |                                         384
              16 |                                         256
              32 |                                         588
              64 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  271658
             128 |                                         320
             256 |                                         688
             512 |                                         24
            1024 |                                         408
            2048 |                                         280
            4096 |                                         0
            8192 |                                         0
           16384 |                                         192
           32768 |                                         0
           65536 |                                         0
          131072 |                                         0
          262144 |                                         288
          524288 |                                         0
         1048576 |                                         96
         2097152 |                                         0

With the fix, the distribution looks significantly saner:

           value  ------------- Distribution ------------- count
               2 |                                         0
               4 |                                         111
               8 |@                                        409
              16 |@@@@@                                    1699
              32 |@@@@@@@@@@@@@                            4320
              64 |@@@@@@@@@@                               3218
             128 |@@                                       565
             256 |@@@                                      925
             512 |                                         160
            1024 |@@                                       678
            2048 |@                                        299
            4096 |                                         2
            8192 |                                         7
           16384 |@                                        200
           32768 |                                         3
           65536 |                                         0
          131072 |                                         0
          262144 |@                                        297
          524288 |                                         0
         1048576 |                                         99
         2097152 |                                         0

Note: I haven't done any benchmarking.