### PR TITLE
exchange mid & left mouse button.

### DIFF
--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -446,7 +446,7 @@ void Waterfall::mouseMoveEvent(QMouseEvent* event)
             // pan viewable range or move center frequency
             int delta_px = m_Xzero - pt.x();
             qint64 delta_hz = delta_px * m_Span / m_OverlayPixmap.width();
-            if (event->buttons() & Qt::MidButton)
+            if (event->buttons() & Qt::LeftButton)
             {
               if (!m_Locked) {
                 m_CenterFreq += delta_hz;


### PR DESCRIPTION
Hi, I switched the btns left & middle for mouse on Waterfall spectrum.

Previous behavior:
* left hold of btn mouse moved the picture of spectrum
* middle hold of btn mouse changed the freq

New behavior:
* left hold of btn mouse change frequency
* middle hold of btn mouse move the picture of spectrum

Reason:
* Have compatible behavior like others (SDR#, etc)
* "browsing" the frequencies is much often, than moving with the picture. So holding left btn is much easier than middle.
