### PR TITLE
Limit plotter/waterfall frequency bounds to bandwidth

### DIFF
--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -1282,23 +1282,40 @@ void
 GLWaterfall::zoomStepX(float step, int x)
 {
   // calculate new range shown on FFT
-  qreal new_range = qBound(10.0,
-                           (qreal)(m_Span) * step,
-                           (qreal)(m_SampleFreq) * 10.0);
+  float new_span = std::min(
+      (float)m_Span * (float)step, (float)m_SampleFreq);
 
-  // Frequency where event occured is kept fixed under mouse
-  qreal ratio = (qreal)x / (qreal)m_OverlayPixmap.width();
-  qreal fixed_hz = fftFreqFromX(x);
-  qreal f_max = fixed_hz + (1.0 - ratio) * new_range;
-  qreal f_min = f_max - new_range;
+  // Keep frequency under pointer the same and calculated the offset to the
+  // plot center.
+  float offset = (float)(freqFromX(x) - m_CenterFreq - m_FftCenter);
+  float new_FftCenter = (float)m_FftCenter + offset * (1.0f - step);
 
-  qint64 fc = (qint64)(f_min + (f_max - f_min) / 2.0);
+  // Keep edges of plot in valid frequency range. The plot may need to be
+  // panned.
+  const float max_limit = (float)m_SampleFreq / 2.0f;
+  const float min_limit = - (float)m_SampleFreq / 2.0f;
+  float f_max = new_FftCenter + new_span / 2.0f;
+  float f_min = new_FftCenter - new_span / 2.0f;
+  if (f_min < min_limit)
+  {
+    f_min = min_limit;
+    f_max = f_min + new_span;
+  }
+  if (f_max > max_limit)
+  {
+    f_max = max_limit;
+    f_min = f_max - new_span;
+  }
 
-  setFftCenterFreq(fc);
-  setSpanFreq(new_range);
+  // Explicitly set m_Span instead of calling setSpanFreq(), which also calls
+  // setFftCenterFreq() and updateOverlay() internally. Span needs to be set
+  // before frequency limits can be checked in setFftCenterFreq().
+  m_Span = new_span;
+  setFftCenterFreq(qRound64((f_max + f_min) / 2.0f));
+  updateOverlay();
 
-  qreal factor = (qreal)m_SampleFreq / (qreal)m_Span;
-  emit newZoomLevel(factor);
+  double zoom = (double)m_SampleFreq / (double)m_Span;
+  emit newZoomLevel(zoom);
 
   m_PeakHoldValid = false;
 }

--- a/GLWaterfall.h
+++ b/GLWaterfall.h
@@ -461,7 +461,7 @@ public:
     }
 
     void setFftCenterFreq(qint64 f) {
-        qint64 limit = ((qint64)m_SampleFreq + m_Span) / 2 - 1;
+        qint64 limit = m_SampleFreq >= m_Span ? ((qint64)m_SampleFreq - m_Span) / 2 : 0;
         m_FftCenter = qBound(-limit, f, limit);
     }
 

--- a/Waterfall.h
+++ b/Waterfall.h
@@ -272,7 +272,7 @@ public:
     }
 
     void setFftCenterFreq(qint64 f) {
-        qint64 limit = ((qint64)m_SampleFreq + m_Span) / 2 - 1;
+        qint64 limit = m_SampleFreq >= m_Span ? ((qint64)m_SampleFreq - m_Span) / 2 : 0;
         m_FftCenter = qBound(-limit, f, limit);
     }
 


### PR DESCRIPTION
This is a matter of opinion whether or not you want to do this, though it mirrors a recent change in Gqrx, and I personally feel it improves usability.