### PR TITLE
Properly handle smooth scrolling

### DIFF
--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -1319,14 +1319,14 @@ GLWaterfall::wheelEvent(QWheelEvent * event)
 #else
     QPointF pt = event->pos();
 #endif // QT_VERSION
-  int numDegrees = event->angleDelta().y() / 8;
-  int numSteps = numDegrees / 15;  /** FIXME: Only used for direction **/
 
-  /** FIXME: zooming could use some optimisation **/
+  // delta is in eigths of a degree, 15 degrees is one step
+  double numSteps = event->angleDelta().y() / (8.0 * 15.0);
+
   if (m_CursorCaptured == YAXIS) {
     // Vertical zoom. Wheel down: zoom out, wheel up: zoom in
     // During zoom we try to keep the point (dB or kHz) under the cursor fixed
-    qreal zoom_fac = event->angleDelta().y() < 0 ? 1. / .9 : 0.9;
+    qreal zoom_fac = pow(0.9, numSteps);
     qreal ratio = pt.y() / m_OverlayPixmap.height();
     qreal db_range = m_PandMaxdB - m_PandMindB;
     qreal y_range = m_OverlayPixmap.height();
@@ -1346,7 +1346,7 @@ GLWaterfall::wheelEvent(QWheelEvent * event)
 
     emit pandapterRangeChanged(m_PandMindB, m_PandMaxdB);
   } else if (m_CursorCaptured == XAXIS) {
-    zoomStepX(event->angleDelta().y() < 0 ? 1.1 : 0.9, pt.x());
+    zoomStepX(pow(0.9, numSteps), pt.x());
   } else if (event->modifiers() & Qt::ControlModifier) {
     // filter width
     m_DemodLowCutFreq -= numSteps * m_ClickResolution;

--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -1343,6 +1343,9 @@ GLWaterfall::wheelEvent(QWheelEvent * event)
       m_PandMaxdB = FFT_MAX_DB;
 
     m_PandMindB = m_PandMaxdB - db_range;
+    if (m_PandMindB < FFT_MIN_DB)
+      m_PandMindB = FFT_MIN_DB;
+
     m_PeakHoldValid = false;
 
     emit pandapterRangeChanged(m_PandMindB, m_PandMaxdB);

--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -759,6 +759,7 @@ GLWaterfall::initDefaults(void)
   m_PandMaxdB = m_WfMaxdB = 0.f;
   m_PandMindB = m_WfMindB = -150.f;
 
+  m_CumWheelDelta = 0;
   m_FreqUnits = 1000000;
   m_CursorCaptured = NOCAP;
   m_Running = false;
@@ -1363,6 +1364,12 @@ GLWaterfall::wheelEvent(QWheelEvent * event)
     }
   } else {
     if (!m_Locked) {
+      // small steps will be lost by roundFreq, let them accumulate
+      m_CumWheelDelta += event->angleDelta().y();
+      if (abs(m_CumWheelDelta) < 8*15)
+        return;
+      numSteps = m_CumWheelDelta / (8.0 * 15.0);
+
       // inc/dec demod frequency
       m_DemodCenterFreq += (numSteps * m_ClickResolution);
       m_DemodCenterFreq = roundFreq(m_DemodCenterFreq, m_ClickResolution );
@@ -1371,6 +1378,7 @@ GLWaterfall::wheelEvent(QWheelEvent * event)
   }
 
   updateOverlay();
+  m_CumWheelDelta = 0;
 }
 
 // Called when screen size changes so must recalculate bitmaps

--- a/GLWaterfall.h
+++ b/GLWaterfall.h
@@ -644,6 +644,7 @@ private:
     qint64      m_Span;
     float       m_SampleFreq;    /*!< Sample rate. */
     qint32      m_FreqUnits;
+    qint32      m_CumWheelDelta;
     int         m_ClickResolution;
     int         m_FilterClickResolution;
 

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -389,9 +389,16 @@ LCD::wheelEvent(QWheelEvent *ev)
 #else
     int x = ev->x();
 #endif // QT_VERSION
-    int amount = ev->angleDelta().y() > 0 ? 1 : -1;
+
+    // accumulate small wheel events up to a step
+    cumWheelDelta += ev->angleDelta().y();
+    int numSteps = cumWheelDelta / (8*15);
+    if (abs(numSteps) == 0)
+        return;
+    cumWheelDelta = 0;
+
     int digit = (this->width - x) / this->glyphWidth;
-    this->scrollDigit(digit, amount);
+    this->scrollDigit(digit, numSteps > 0 ? 1 : -1);
     ev->accept();
   }
 }

--- a/LCD.h
+++ b/LCD.h
@@ -123,6 +123,7 @@ class LCD : public QFrame
   int height;
   int glyphWidth;
   int glyphHeight;
+  int cumWheelDelta = 0;
   qreal segBoxThickness;
   qreal segBoxLength;
   qreal segThickness;

--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -791,15 +791,14 @@ void Waterfall::wheelEvent(QWheelEvent * event)
     QPointF pt = event->pos();
 #endif // QT_VERSION
 
-    int numDegrees = event->angleDelta().y() / 8;
-    int numSteps = numDegrees / 15;  /** FIXME: Only used for direction **/
+    // delta is in eigths of a degree, 15 degrees is one step
+    double numSteps = event->angleDelta().y() / (8.0 * 15.0);
 
-    /** FIXME: zooming could use some optimisation **/
     if (m_CursorCaptured == YAXIS)
     {
         // Vertical zoom. Wheel down: zoom out, wheel up: zoom in
         // During zoom we try to keep the point (dB or kHz) under the cursor fixed
-      qreal zoom_fac = event->angleDelta().y() < 0 ? 1. / .9 : 0.9;
+      qreal zoom_fac = pow(0.9, numSteps);
       qreal ratio = pt.y() / m_OverlayPixmap.height();
       qreal db_range = m_PandMaxdB - m_PandMindB;
       qreal y_range = m_OverlayPixmap.height();
@@ -821,7 +820,7 @@ void Waterfall::wheelEvent(QWheelEvent * event)
     }
     else if (m_CursorCaptured == XAXIS)
     {
-        zoomStepX(event->angleDelta().y() < 0 ? 1.1 : 0.9, pt.x());
+        zoomStepX(pow(0.9, numSteps), pt.x());
     }
     else if (event->modifiers() & Qt::ControlModifier)
     {

--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -815,6 +815,9 @@ void Waterfall::wheelEvent(QWheelEvent * event)
             m_PandMaxdB = FFT_MAX_DB;
 
         m_PandMindB = m_PandMaxdB - db_range;
+        if (m_PandMindB < FFT_MIN_DB)
+            m_PandMindB = FFT_MIN_DB;
+
         m_PeakHoldValid = false;
 
         emit pandapterRangeChanged(m_PandMindB, m_PandMaxdB);

--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -123,6 +123,7 @@ Waterfall::Waterfall(QWidget *parent) : QFrame(parent)
     m_PandMaxdB = m_WfMaxdB = 0.f;
     m_PandMindB = m_WfMindB = -150.f;
 
+    m_CumWheelDelta = 0;
     m_FreqUnits = 1000000;
     m_CursorCaptured = NOCAP;
     m_Running = false;
@@ -844,6 +845,12 @@ void Waterfall::wheelEvent(QWheelEvent * event)
     else
     {
       if (!m_Locked) {
+        // small steps will be lost by roundFreq, let them accumulate
+        m_CumWheelDelta += event->angleDelta().y();
+        if (abs(m_CumWheelDelta) < 8*15)
+            return;
+        numSteps = m_CumWheelDelta / (8.0 * 15.0);
+
         // inc/dec demod frequency
         m_DemodCenterFreq += (numSteps * m_ClickResolution);
         m_DemodCenterFreq = roundFreq(m_DemodCenterFreq, m_ClickResolution );
@@ -852,6 +859,7 @@ void Waterfall::wheelEvent(QWheelEvent * event)
     }
 
     updateOverlay();
+    m_CumWheelDelta = 0;
 }
 
 // Called when screen size changes so must recalculate bitmaps

--- a/Waterfall.h
+++ b/Waterfall.h
@@ -458,6 +458,7 @@ private:
     qint64      m_Span;
     float       m_SampleFreq;    /*!< Sample rate. */
     qint32      m_FreqUnits;
+    qint32      m_CumWheelDelta;
     int         m_ClickResolution;
     int         m_FilterClickResolution;
 


### PR DESCRIPTION
On devices with smooth scrolling (like Mac laptops) that issue very frequent scroll events with small deltas, the current scrolling/zooming logic that only checks the sign of the delta and not the magnitude made scrolling/zooming excessively fast, jittery, and generally unusable. These changes make scrolling to zoom or adjust frequencies smooth and precise on devices with smooth scrolling, while also maintaining the original behaviour on old-fashioned mice that only did whole steps per eight degree click.

I also fixed a bug that allowed zooming to signal strength magnitudes below the minimum permitted, when zooming with the mouse near the bottom of the Y-axis.