### PR TITLE
Waterfall and miscellaneous improvements

### DIFF
--- a/FrequencySpinBox.cpp
+++ b/FrequencySpinBox.cpp
@@ -136,9 +136,9 @@ FrequencySpinBox::connectAll(void)
 
   connect(
         this->ui->frequencySpin,
-        SIGNAL(valueChanged(double)),
+        SIGNAL(editingFinished(void)),
         this,
-        SLOT(onValueChanged(double)));
+        SLOT(onEditingFinished(void)));
 }
 
 
@@ -236,7 +236,8 @@ FrequencySpinBox::subMultiplesAllowed() const
 double
 FrequencySpinBox::value(void) const
 {
-  return currValue;
+  // this->currValue may be outdated if editing was in progress
+  return this->ui->frequencySpin->value() * this->freqMultiplier();
 }
 
 void
@@ -359,10 +360,10 @@ FrequencySpinBox::setFocus(void)
 
 ///////////////////////////////// Slots ///////////////////////////////////////
 void
-FrequencySpinBox::onValueChanged(double freq)
+FrequencySpinBox::onEditingFinished(void)
 {
   if (!this->refreshing) {
-    this->currValue = freq * this->freqMultiplier();
+    this->currValue = this->ui->frequencySpin->value() * this->freqMultiplier();
     emit valueChanged(this->currValue);
   }
 }

--- a/FrequencySpinBox.h
+++ b/FrequencySpinBox.h
@@ -103,7 +103,7 @@ signals:
   void valueChanged(double freq);
 
 public slots:
-  void onValueChanged(double freq);
+  void onEditingFinished(void);
   void onIncFreqUnitMultiplier(void);
   void onDecFreqUnitMultiplier(void);
 

--- a/FrequencySpinBox.ui
+++ b/FrequencySpinBox.ui
@@ -48,9 +48,6 @@
      <property name="buttonSymbols">
       <enum>QAbstractSpinBox::UpDownArrows</enum>
      </property>
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
      <property name="showGroupSeparator" stdset="0">
       <bool>false</bool>
      </property>

--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -856,7 +856,11 @@ GLWaterfall::mouseMoveEvent(QMouseEvent *event)
         m_CursorCaptured = CENTER;
         if (m_TooltipsEnabled)
           QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                event->globalPosition().toPoint(),
+#else
                 event->globalPos(),
+#endif
                 QString("Demod: %1 kHz").arg(
                   m_DemodCenterFreq / 1.e3f, 0, 'f', 3),
                 this);
@@ -870,7 +874,11 @@ GLWaterfall::mouseMoveEvent(QMouseEvent *event)
         m_CursorCaptured = RIGHT;
         if (m_TooltipsEnabled)
           QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                event->globalPosition().toPoint(),
+#else
                 event->globalPos(),
+#endif
                 QString("High cut: %1 Hz").arg(m_DemodHiCutFreq),
                 this);
       } else if (isPointCloseTo(
@@ -883,7 +891,11 @@ GLWaterfall::mouseMoveEvent(QMouseEvent *event)
         m_CursorCaptured = LEFT;
         if (m_TooltipsEnabled)
           QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                event->globalPosition().toPoint(),
+#else
                 event->globalPos(),
+#endif
                 QString("Low cut: %1 Hz").arg(m_DemodLowCutFreq),
                 this);
       } else if (isPointCloseTo(
@@ -911,7 +923,11 @@ GLWaterfall::mouseMoveEvent(QMouseEvent *event)
         }
         if (m_TooltipsEnabled)
           QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                event->globalPosition().toPoint(),
+#else
                 event->globalPos(),
+#endif
                 QString("F: %1 kHz").arg(freqFromX(pt.x())/1.e3f, 0, 'f', 3),
                 this);
       }
@@ -931,7 +947,11 @@ GLWaterfall::mouseMoveEvent(QMouseEvent *event)
       tt.setMSecsSinceEpoch(msecFromY(pt.y()));
 
       QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            event->globalPosition().toPoint(),
+#else
             event->globalPos(),
+#endif
             QString("%1\n%2 kHz")
               .arg(tt.toString("yyyy.MM.dd hh:mm:ss.zzz"))
               .arg(freqFromX(pt.x())/1.e3f, 0, 'f', 3),

--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -1528,12 +1528,13 @@ GLWaterfall::paintTimeStamps(
   int textHeight = metrics.height();
   int items = 0;
   int leftSpacing = 0;
+  int dpi_factor = screen()->devicePixelRatio();
 
   auto it = m_TimeStamps.begin();
 
   painter.setFont(m_Font);
 
-  y += m_TimeStampCounter;
+  y += m_TimeStampCounter / dpi_factor;
 
   if (m_TimeStampMaxHeight < where.height())
     m_TimeStampMaxHeight = where.height();
@@ -1566,7 +1567,7 @@ GLWaterfall::paintTimeStamps(
       painter.drawLine(where.x(), y, textWidth + where.x(), y);
     }
 
-    y += it->counter;
+    y += it->counter / dpi_factor;
     ++it;
     ++items;
   }

--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -1307,13 +1307,13 @@ GLWaterfall::zoomStepX(float step, int x)
 
   // Frequency where event occured is kept fixed under mouse
   qreal ratio = (qreal)x / (qreal)m_OverlayPixmap.width();
-  qreal fixed_hz = fftFreqFromX(x);
+  qreal fixed_hz = freqFromX(x);
   qreal f_max = fixed_hz + (1.0 - ratio) * new_range;
   qreal f_min = f_max - new_range;
 
   qint64 fc = (qint64)(f_min + (f_max - f_min) / 2.0);
 
-  setFftCenterFreq(fc);
+  setFftCenterFreq(fc - m_CenterFreq);
   setSpanFreq(new_range);
 
   qreal factor = (qreal)m_SampleFreq / (qreal)m_Span;

--- a/GLWaterfall.cpp
+++ b/GLWaterfall.cpp
@@ -562,12 +562,12 @@ GLWaterfallOpenGLContext::averageFFTData(const float *fftData, int size)
   }
 
   if (m_firstAccum) {
-    m_accum.assign(m_accum.size(), 0);
+    std::memcpy(m_accum.data(), fftData, size * sizeof(float));
     m_firstAccum = false;
+  } else {
+    for (i = 0; i < size; ++i)
+      m_accum[i] += .5f * (fftData[i] - m_accum[i]);
   }
-
-  for (i = 0; i < size; ++i)
-   m_accum[i] += .5f * (fftData[i] - m_accum[i]);
 }
 
 void

--- a/GLWaterfall.h
+++ b/GLWaterfall.h
@@ -467,7 +467,7 @@ public:
 
     int     getNearestPeak(QPoint pt);
     void    setWaterfallSpan(quint64 span_ms);
-    quint64 getWfTimeRes(void);
+    double  getWfTimeRes(void);
     void    setFftRate(int rate_hz);
     void    clearGLWaterfall(void);
     bool    saveGLWaterfall(const QString & filename) const;
@@ -687,9 +687,9 @@ private:
     qint64      m_upperFreqLimit    = 300000000;
 
     // Waterfall averaging
-    quint64     tlast_wf_ms;        // last time waterfall has been updated
-    quint64     msec_per_wfline;    // milliseconds between waterfall updates
-    quint64     wf_span;            // waterfall span in milliseconds (0 = auto)
+    double      tlast_wf_ms;        // last time waterfall has been updated
+    double      msec_per_wfline;    // milliseconds between waterfall updates
+    double      wf_span;            // waterfall span in milliseconds (0 = auto)
     int         fft_rate;           // expected FFT rate (needed when WF span is auto)
     int         m_expectedRate;
 

--- a/Histogram.cpp
+++ b/Histogram.cpp
@@ -558,7 +558,11 @@ Histogram::mouseMoveEvent(QMouseEvent *event)
   if (this->selecting) {
     float x;
     x = HORIZONTAL_SCALE_INV * (
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+          static_cast<float>(event->position().x())  / this->width - LEFT_MARGIN);
+#else
           static_cast<float>(event->x())  / this->width - LEFT_MARGIN);
+#endif
     this->sEnd = x;
     this->invalidateHard();
   }
@@ -569,7 +573,11 @@ Histogram::mousePressEvent(QMouseEvent *event)
 {  if (event->button() == Qt::MouseButton::LeftButton) {
     float x;
     x = HORIZONTAL_SCALE_INV * (
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+          static_cast<float>(event->position().x())  / this->width - LEFT_MARGIN);
+#else
           static_cast<float>(event->x())  / this->width - LEFT_MARGIN);
+#endif
     this->selecting = true;
     this->sStart = x;
     this->sEnd = x;
@@ -589,7 +597,11 @@ Histogram::mouseReleaseEvent(QMouseEvent *event)
     float add;
     int intervals = 1 << this->bits;
     x = HORIZONTAL_SCALE_INV * (
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+          static_cast<float>(event->position().x())  / this->width - LEFT_MARGIN);
+#else
           static_cast<float>(event->x())  / this->width - LEFT_MARGIN);
+#endif
     this->sEnd = x;
     this->selecting = false;
 

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -344,11 +344,19 @@ void
 LCD::mousePressEvent(QMouseEvent *ev)
 {
   if (this->haveLockRect)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (this->lockRect.contains(ev->position()))
+#else
     if (this->lockRect.contains(ev->x(), ev->y()))
+#endif
       this->setLocked(!this->isLocked());
 
   if (this->glyphWidth > 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    this->selectDigit((this->width - ev->position().x()) / this->glyphWidth);
+#else
     this->selectDigit((this->width - ev->x()) / this->glyphWidth);
+#endif
 }
 
 void
@@ -420,7 +428,11 @@ LCD::mouseMoveEvent(QMouseEvent *event)
   }
 
   if (rect.contains(event->pos()))
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    digit = (this->width - event->position().x()) / this->glyphWidth;
+#else
     digit = (this->width - event->x()) / this->glyphWidth;
+#endif
 
   if (digit != this->hoverDigit) {
     this->hoverDigit = digit;

--- a/SymView.cpp
+++ b/SymView.cpp
@@ -457,8 +457,13 @@ SymView::coordToOffset(int x, int y)
 void
 SymView::mouseMoveEvent(QMouseEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  hoverX = event->position().x();
+  hoverY = event->position().y();
+#else
   hoverX = event->x();
   hoverY = event->y();
+#endif
 
   if (this->selecting) {
     qint64 end   = this->coordToOffset(hoverX, hoverY);

--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -770,7 +770,6 @@ void Waterfall::zoomStepX(float step, int x)
 
     float factor = (float)m_SampleFreq / (float)m_Span;
     emit newZoomLevel(factor);
-    qDebug() << QString("Spectrum zoom: %1x").arg(factor, 0, 'f', 1);
 
     m_PeakHoldValid = false;
 }

--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -215,7 +215,12 @@ void Waterfall::mouseMoveEvent(QMouseEvent* event)
                     setCursor(QCursor(Qt::SizeHorCursor));
                 m_CursorCaptured = CENTER;
                 if (m_TooltipsEnabled)
-                    QToolTip::showText(event->globalPos(),
+                    QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                                       event->globalPosition().toPoint(),
+#else
+                                       event->globalPos(),
+#endif
                                        QString("Demod: %1 kHz")
                                        .arg(m_DemodCenterFreq/1.e3f, 0, 'f', 3),
                                        this);
@@ -227,7 +232,12 @@ void Waterfall::mouseMoveEvent(QMouseEvent* event)
                     setCursor(QCursor(Qt::SizeFDiagCursor));
                 m_CursorCaptured = RIGHT;
                 if (m_TooltipsEnabled)
-                    QToolTip::showText(event->globalPos(),
+                    QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                                       event->globalPosition().toPoint(),
+#else
+                                       event->globalPos(),
+#endif
                                        QString("High cut: %1 Hz")
                                        .arg(m_DemodHiCutFreq),
                                        this);
@@ -239,7 +249,12 @@ void Waterfall::mouseMoveEvent(QMouseEvent* event)
                     setCursor(QCursor(Qt::SizeBDiagCursor));
                 m_CursorCaptured = LEFT;
                 if (m_TooltipsEnabled)
-                    QToolTip::showText(event->globalPos(),
+                    QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                                       event->globalPosition().toPoint(),
+#else
+                                       event->globalPos(),
+#endif
                                        QString("Low cut: %1 Hz")
                                        .arg(m_DemodLowCutFreq),
                                        this);
@@ -268,7 +283,12 @@ void Waterfall::mouseMoveEvent(QMouseEvent* event)
                     m_CursorCaptured = NOCAP;
                 }
                 if (m_TooltipsEnabled)
-                    QToolTip::showText(event->globalPos(),
+                    QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                                       event->globalPosition().toPoint(),
+#else
+                                       event->globalPos(),
+#endif
                                        QString("F: %1 kHz")
                                        .arg(freqFromX(pt.x())/1.e3f, 0, 'f', 3),
                                        this);
@@ -292,7 +312,12 @@ void Waterfall::mouseMoveEvent(QMouseEvent* event)
             QDateTime tt;
             tt.setMSecsSinceEpoch(msecFromY(pt.y()));
 
-            QToolTip::showText(event->globalPos(),
+            QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                               event->globalPosition().toPoint(),
+#else
+                               event->globalPos(),
+#endif
                                QString("%1\n%2 kHz")
                                .arg(tt.toString("yyyy.MM.dd hh:mm:ss.zzz"))
                                .arg(freqFromX(pt.x())/1.e3f, 0, 'f', 3),

--- a/Waterfall.h
+++ b/Waterfall.h
@@ -278,7 +278,7 @@ public:
 
     int     getNearestPeak(QPoint pt);
     void    setWaterfallSpan(quint64 span_ms);
-    quint64 getWfTimeRes(void);
+    double  getWfTimeRes(void);
     void    setFftRate(int rate_hz);
     void    clearWaterfall(void);
     bool    saveWaterfall(const QString & filename) const;
@@ -300,7 +300,7 @@ public:
 
     NamedChannelSetIterator channelCBegin() const;
     NamedChannelSetIterator channelCEnd() const;
-    
+
 signals:
     void newCenterFreq(qint64 f);
     void newDemodFreq(qint64 freq, qint64 delta); /* delta is the offset from the center */
@@ -501,9 +501,9 @@ private:
     qint64      m_upperFreqLimit    = 300000000;
 
     // Waterfall averaging
-    quint64     tlast_wf_ms;        // last time waterfall has been updated
-    quint64     msec_per_wfline;    // milliseconds between waterfall updates
-    quint64     wf_span;            // waterfall span in milliseconds (0 = auto)
+    double      tlast_wf_ms;        // last time waterfall has been updated
+    double      msec_per_wfline;    // milliseconds between waterfall updates
+    double      wf_span;            // waterfall span in milliseconds (0 = auto)
     int         fft_rate;           // expected FFT rate (needed when WF span is auto)
     int         m_expectedRate;
 

--- a/WaveViewTree.cpp
+++ b/WaveViewTree.cpp
@@ -135,7 +135,7 @@ WaveWorker::build(SUSCOUNT start, SUSCOUNT end)
 void
 WaveWorker::cancel()
 {
-  QMutexLocker(&this->mutex);
+  QMutexLocker locker(&this->mutex);
 
   this->cancelFlag = true;
 }

--- a/Waveform.cpp
+++ b/Waveform.cpp
@@ -455,16 +455,32 @@ Waveform::mouseMoveEvent(QMouseEvent *event)
 {
   // Emit mouseMove
   this->haveCursor = true;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  this->currMouseX = event->position().x();
+#else
   this->currMouseX = event->x();
+#endif
 
   if (this->frequencyDragging)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    this->scrollHorizontal(this->clickX, event->position().x());
+#else
     this->scrollHorizontal(this->clickX, event->x());
+#endif
   else if (this->valueDragging)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    this->scrollVertical(this->clickY, event->position().y());
+#else
     this->scrollVertical(this->clickY, event->y());
+#endif
   else if (this->hSelDragging)
     this->selectHorizontal(
           static_cast<qint64>(this->px2samp(this->samp2px(this->clickSample))),
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+          static_cast<qint64>(this->px2samp(event->position().x())));
+#else
           static_cast<qint64>(this->px2samp(event->x())));
+#endif
 
   emit hoverTime(this->px2t(this->currMouseX));
   this->invalidate();
@@ -481,8 +497,13 @@ Waveform::mousePressEvent(QMouseEvent *event)
     this->saveHorizontal();
     this->saveVertical();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    this->clickX = event->position().x();
+    this->clickY = event->position().y();
+#else
     this->clickX = event->x();
     this->clickY = event->y();
+#endif
 
     this->clickSample = this->px2samp(this->clickX);
 


### PR DESCRIPTION
- Always have a precise waterfall timespan, even with short durations, by repeating the last waterfall line if necessary
- GLWaterfall hidpi fixes
- Improved GLWaterfall averaging logic for short averaging sample counts (short waterfall timespans)
- Give up-to-date value from FrequencySpinBox when it was the last item edited and in focus
- Reduced frequency drift in GLWaterfall frequency zoom (though more improvement can be made)
- Fixed compiler warnings