### PR TITLE
Allow updating a subset of waterfall frequency range

### DIFF
--- a/AbstractWaterfall.cpp
+++ b/AbstractWaterfall.cpp
@@ -1134,7 +1134,10 @@ void AbstractWaterfall::setNewPartialFftData(
     bool looped)
 {
   if (!m_partialFreqActive) {
+    size_t k = 1;
     size_t full_size = size * m_SampleFreq / (endFreq - startFreq);
+    while (k < full_size) k <<= 1;
+    full_size = k; // round up to next biggest power of 2 if needed
     m_fullFftData.resize(full_size);
     std::fill(m_fullFftData.begin(), m_fullFftData.end(), -255);
     m_partialFreqActive = true;

--- a/AbstractWaterfall.cpp
+++ b/AbstractWaterfall.cpp
@@ -338,7 +338,8 @@ void AbstractWaterfall::mouseMoveEvent(QMouseEvent* event)
         // pan viewable range or move center frequency
         int delta_px = m_Xzero - pt.x();
         qint64 delta_hz = delta_px * m_Span / m_Size.width();
-        if (event->buttons() & m_freqDragBtn)
+        if ((event->buttons() & m_freqDragBtn) ||
+            (event->modifiers() & Qt::ShiftModifier))
         {
           if (!m_Locked && !m_freqDragLocked) {
             qint64 centerFreq = boundCenterFreq(roundFreq(

--- a/AbstractWaterfall.cpp
+++ b/AbstractWaterfall.cpp
@@ -750,8 +750,7 @@ void AbstractWaterfall::zoomStepX(float step, int x)
   m_Span = new_range;
   setFftCenterFreq(fc - m_CenterFreq);
 
-  float factor = (float)m_SampleFreq / (float)m_Span;
-  emit newZoomLevel(factor);
+  emit newZoomLevel(getZoomLevel());
 
   m_PeakHoldValid = false;
 }

--- a/AbstractWaterfall.cpp
+++ b/AbstractWaterfall.cpp
@@ -1307,9 +1307,23 @@ void AbstractWaterfall::getScreenIntegerFFTData(qint32 plotHeight, qint32 plotWi
     qint64 startFreq, qint64 stopFreq,
     qint32 *outBuf, qint32 *xmin, qint32 *xmax)
 {
-  getScreenIntegerFFTData(plotHeight, plotWidth, maxdB, mindB, startFreq, stopFreq,
-      m_fftData, m_SampleFreq, m_fftDataSize,
-      outBuf, xmin, xmax);
+  // startFreq and stopFreq are relative to m_CenterFreq
+  qint64 absStartFreq = startFreq + m_CenterFreq;
+  qint64 absStopFreq = stopFreq + m_CenterFreq;
+
+  if (!m_partialFftData || absStartFreq < m_partialFreqStart || absStopFreq > m_partialFreqEnd)
+  {
+    getScreenIntegerFFTData(plotHeight, plotWidth, maxdB, mindB, startFreq, stopFreq,
+        m_fftData, m_SampleFreq, m_fftDataSize,
+        outBuf, xmin, xmax);
+  } else {
+    qint64 relPartialCenter = m_partialFreqStart +
+        (m_partialFreqEnd - m_partialFreqStart)/2  - m_CenterFreq;
+    getScreenIntegerFFTData(plotHeight, plotWidth, maxdB, mindB,
+        startFreq - relPartialCenter, stopFreq - relPartialCenter,
+        m_partialFftData, m_partialFreqEnd - m_partialFreqStart, m_partialFftDataSize,
+        outBuf, xmin, xmax);
+  }
 }
 
 void AbstractWaterfall::setFftRange(float min, float max)

--- a/AbstractWaterfall.cpp
+++ b/AbstractWaterfall.cpp
@@ -341,7 +341,8 @@ void AbstractWaterfall::mouseMoveEvent(QMouseEvent* event)
         if (event->buttons() & m_freqDragBtn)
         {
           if (!m_Locked && !m_freqDragLocked) {
-            qint64 centerFreq = boundCenterFreq(m_CenterFreq + delta_hz);
+            qint64 centerFreq = boundCenterFreq(roundFreq(
+                  m_CenterFreq + delta_hz, m_ClickResolution));
             delta_hz = centerFreq - m_CenterFreq;
 
             m_CenterFreq += delta_hz;
@@ -359,11 +360,11 @@ void AbstractWaterfall::mouseMoveEvent(QMouseEvent* event)
           setFftCenterFreq(m_FftCenter + delta_hz);
         }
 
-        updateOverlay();
-
-        m_PeakHoldValid = false;
-
-        m_Xzero = pt.x();
+        if (delta_hz != 0) {
+          updateOverlay();
+          m_PeakHoldValid = false;
+          m_Xzero = pt.x();
+        }
       }
   }
   else if (LEFT == m_CursorCaptured)

--- a/AbstractWaterfall.h
+++ b/AbstractWaterfall.h
@@ -231,6 +231,11 @@ class AbstractWaterfall : public QOpenGLWidget
       return static_cast<quint64>(this->m_Span);
     }
 
+    float getZoomLevel(void) const
+    {
+      return (float)m_SampleFreq / m_Span;
+    }
+
     qint64 getFftCenterFreq(void) const
     {
       return this->m_FftCenter;
@@ -242,7 +247,7 @@ class AbstractWaterfall : public QOpenGLWidget
     void setFreqDigits(int digits) { m_FreqDigits = digits>=0 ? digits : 0; }
 
     /* Determines full bandwidth. */
-    void setSampleRate(float rate)
+    void setSampleRate(double rate)
     {
       if (rate > 0.0)
       {
@@ -251,7 +256,7 @@ class AbstractWaterfall : public QOpenGLWidget
       }
     }
 
-    float getSampleRate(void)
+    double getSampleRate(void)
     {
       return m_SampleFreq;
     }
@@ -490,7 +495,7 @@ class AbstractWaterfall : public QOpenGLWidget
     BookmarkSource *m_BookmarkSource = nullptr;
 #endif // WATERFALL_BOOKMARKS_SUPPORT
     qint64      m_Span;
-    float       m_SampleFreq;    /*!< Sample rate. */
+    double      m_SampleFreq;    /*!< Sample rate. */
     qint32      m_FreqUnits;
     qint32      m_CumWheelDelta;
     int         m_ClickResolution;

--- a/AbstractWaterfall.h
+++ b/AbstractWaterfall.h
@@ -397,8 +397,12 @@ class AbstractWaterfall : public QOpenGLWidget
     void getScreenIntegerFFTData(qint32 plotHeight, qint32 plotWidth,
         float maxdB, float mindB,
         qint64 startFreq, qint64 stopFreq,
-        const float *inBuf, qint32 *outBuf,
-        qint32 *maxbin, qint32 *minbin);
+        const float *inBuf, qint64 inSampleFreq, int inFftSize,
+        qint32 *outBuf, qint32 *xmin, qint32 *xmax);
+    void getScreenIntegerFFTData(qint32 plotHeight, qint32 plotWidth,
+        float maxdB, float mindB,
+        qint64 startFreq, qint64 stopFreq,
+        qint32 *outBuf, qint32 *xmin, qint32 *xmax);
     void calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adjlow, qint64 &step, int& divs);
 
     int  drawFATs(DrawingContext &, qint64, qint64);

--- a/AbstractWaterfall.h
+++ b/AbstractWaterfall.h
@@ -258,7 +258,11 @@ class AbstractWaterfall : public QOpenGLWidget
 
     void setFftCenterFreq(qint64 f) {
       qint64 limit = ((qint64)m_SampleFreq + m_Span) / 2 - 1;
-      m_FftCenter = qBound(-limit, f, limit);
+      qint64 center = qBound(-limit, f, limit);
+      if (m_FftCenter != center) {
+        m_FftCenter = center;
+        emit newFftCenterFreq(m_FftCenter);
+      }
     }
 
     int     getNearestPeak(QPoint pt);
@@ -288,6 +292,7 @@ class AbstractWaterfall : public QOpenGLWidget
 
   signals:
     void newCenterFreq(qint64 f);
+    void newFftCenterFreq(qint64 f);
     void newDemodFreq(qint64 freq, qint64 delta); /* delta is the offset from the center */
     void newLowCutFreq(int f);
     void newHighCutFreq(int f);

--- a/AbstractWaterfall.h
+++ b/AbstractWaterfall.h
@@ -110,6 +110,16 @@ class AbstractWaterfall : public QOpenGLWidget
         QDateTime const &t = QDateTime::currentDateTime(),
         bool looped = false);
 
+    void setNewPartialFftData(
+        const float *fftData,
+        int size,
+        qint64 startFreq,
+        qint64 endFreq,
+        QDateTime const &t = QDateTime::currentDateTime(),
+        bool looped = false);
+
+    void clearPartialFftData();
+
     virtual void setPalette(const QColor *table) = 0;
 
     virtual void setMaxBlending(bool val)
@@ -396,6 +406,15 @@ class AbstractWaterfall : public QOpenGLWidget
     // FFT line averaging accumulator
     std::vector<float>  m_accum;
     int                 m_samplesInAccum;
+
+    // In partial update mode, keep a buffer of full frequency range data
+    // Full frequency range is m_CenterFreq +- (m_SampleFreq/2)
+    std::vector<float>  m_fullFftData;
+    const float        *m_partialFftData;
+    int                 m_partialFftDataSize;
+    bool                m_partialFreqActive = false;
+    qint64              m_partialFreqStart;
+    qint64              m_partialFreqEnd;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     Qt::MouseButton m_freqDragBtn = Qt::MiddleButton;

--- a/AbstractWaterfall.h
+++ b/AbstractWaterfall.h
@@ -257,7 +257,7 @@ class AbstractWaterfall : public QOpenGLWidget
     }
 
     void setFftCenterFreq(qint64 f) {
-      qint64 limit = ((qint64)m_SampleFreq + m_Span) / 2 - 1;
+      qint64 limit = m_SampleFreq >= m_Span ? ((qint64)m_SampleFreq - m_Span) / 2 : 0;
       qint64 center = qBound(-limit, f, limit);
       if (m_FftCenter != center) {
         m_FftCenter = center;

--- a/Waterfall.cpp
+++ b/Waterfall.cpp
@@ -230,6 +230,8 @@ Waterfall::addNewWfLine(const float* wfData, int size, int repeats)
           m_tentativeCenterFreq + m_FftCenter,
           limit) + SCAST(qint64, m_Span)/2,
         wfData,
+        m_SampleFreq,
+        m_fftDataSize,
         m_fftbuf,
         &xmin,
         &xmax);


### PR DESCRIPTION
This enables nicer handling of the panoramic spectrum. Also constraint waterfall zoom range to the range with actual data (akin to modern versions of gqrx), respect click resolution in frequency drag to tune, and allow shift drag for retuning as an alternative to the middle button (since many computers don't have a middle mouse button, especially Macs).