### PR TITLE
AbstractWatefall: avoid uninitialized use of m_partialFftData

### DIFF
--- a/AbstractWaterfall.cpp
+++ b/AbstractWaterfall.cpp
@@ -1311,7 +1311,7 @@ void AbstractWaterfall::getScreenIntegerFFTData(qint32 plotHeight, qint32 plotWi
   qint64 absStartFreq = startFreq + m_CenterFreq;
   qint64 absStopFreq = stopFreq + m_CenterFreq;
 
-  if (!m_partialFftData || absStartFreq < m_partialFreqStart || absStopFreq > m_partialFreqEnd)
+  if (!m_partialFreqActive || absStartFreq < m_partialFreqStart || absStopFreq > m_partialFreqEnd)
   {
     getScreenIntegerFFTData(plotHeight, plotWidth, maxdB, mindB, startFreq, stopFreq,
         m_fftData, m_SampleFreq, m_fftDataSize,

--- a/FrequencySpinBox.cpp
+++ b/FrequencySpinBox.cpp
@@ -210,12 +210,16 @@ FrequencySpinBox::setValue(double val)
   double min = this->allowSubMultiples ? this->min : 1.;
 
   if (fabs(val - this->currValue) >= min) {
+    double oldValue = this->currValue;
     this->currValue = val;
 
     if (this->autoUnitMultiplier)
       this->adjustUnitMultiplier();
 
     this->refreshUi();
+
+    if (this->currValue != oldValue)
+      emit valueChanged(this->currValue);
   }
 }
 


### PR DESCRIPTION
This was causing intermittent instances of blank line graphs with normal looking waterfalls.