### PR TITLE
Context Aware Spin Box Improvements

### DIFF
--- a/ContextAwareSpinBox.cpp
+++ b/ContextAwareSpinBox.cpp
@@ -79,12 +79,6 @@ ContextAwareSpinBox::ContextAwareSpinBox(QWidget *parent) : QDoubleSpinBox(paren
   m_baseStyle  = lineEdit()->style();
   m_blockStyle = new BlockCursorStyle(m_baseStyle, this);
 
-  connect(
-        lineEdit(),
-        SIGNAL(cursorPositionChanged(int, int)),
-        this,
-        SLOT(onCursorPositionChanged(int, int)));
-
   lineEdit()->setStyle(m_blockStyle);
 }
 
@@ -194,26 +188,6 @@ ContextAwareSpinBox::setMinimumStep()
 {
   int textLen = static_cast<int>(lineEdit()->text().length());
   lineEdit()->setCursorPosition(textLen);
-}
-
-void
-ContextAwareSpinBox::onCursorPositionChanged(int oldPos, int newPos)
-{
-  int prefixLen = static_cast<int>(prefix().size());
-  int suffixLen = static_cast<int>(suffix().size());
-  int textLen = static_cast<int>(lineEdit()->text().length());
-  int decSize = decimalLength();
-  int intLen = textLen - decSize - (prefixLen + suffixLen);
-  int pos = lineEdit()->cursorPosition() - prefixLen;
-
-  // don't interfere with text selection, since setCursorPosition breaks it
-  if (lineEdit()->hasSelectedText())
-    return;
-
-  if (pos > intLen + decSize)
-    lineEdit()->setCursorPosition(prefixLen + intLen + decSize);
-  else if (pos < 0)
-    lineEdit()->setCursorPosition(prefixLen);
 }
 
 void

--- a/ContextAwareSpinBox.cpp
+++ b/ContextAwareSpinBox.cpp
@@ -120,6 +120,8 @@ ContextAwareSpinBox::currentStep() const
 
   if (pos < 0)
     pos = intLen;
+  else if (pos > intLen + decSize)
+    pos = intLen + decSize;
 
   // 1387.01 --> LEN = 7, DECIMALS = 2
   //             INT = 7 - 2 - 1 = 4
@@ -207,14 +209,6 @@ ContextAwareSpinBox::onCursorPositionChanged(int oldPos, int newPos)
   // don't interfere with text selection, since setCursorPosition breaks it
   if (lineEdit()->hasSelectedText())
     return;
-
-  if (pos == intLen + 1) {
-    if (oldPos < newPos) // Moving forward
-      lineEdit()->setCursorPosition(prefixLen + pos + 1);
-    else // Whatever is this
-      lineEdit()->setCursorPosition(prefixLen + pos - 1);
-    return;
-  }
 
   if (pos > intLen + decSize)
     lineEdit()->setCursorPosition(prefixLen + intLen + decSize);

--- a/ContextAwareSpinBox.cpp
+++ b/ContextAwareSpinBox.cpp
@@ -60,8 +60,7 @@ ContextAwareSpinBox::focusInEvent(QFocusEvent *event)
   int prefixLen = static_cast<int>(prefix().size());
   int suffixLen = static_cast<int>(suffix().size());
   int textLen = static_cast<int>(lineEdit()->text().length());
-  int dec = decimals();
-  int decSize = dec > 0 ? dec + 1 : 0;
+  int decSize = decimalLength();
   int intLen = textLen - decSize - (prefixLen + suffixLen);
 
   lineEdit()->setCursorPosition(prefixLen + intLen);
@@ -93,14 +92,29 @@ ContextAwareSpinBox::~ContextAwareSpinBox()
 {
 }
 
+int
+ContextAwareSpinBox::decimalLength() const
+{
+  int prefixLen = static_cast<int>(prefix().size());
+  int suffixLen = static_cast<int>(suffix().size());
+  int textLen = static_cast<int>(lineEdit()->text().size());
+
+  QString numberText = lineEdit()->text().mid(prefixLen, textLen - prefixLen - suffixLen);
+  int decPos = numberText.indexOf('.');
+
+  if (decPos >= 0)
+    return numberText.size() - decPos;
+  else
+    return 0;
+}
+
 qreal
 ContextAwareSpinBox::currentStep() const
 {
   int prefixLen = static_cast<int>(prefix().size());
   int suffixLen = static_cast<int>(suffix().size());
   int textLen = static_cast<int>(lineEdit()->text().length());
-  int dec = decimals();
-  int decSize = dec > 0 ? dec + 1 : 0;
+  int decSize = decimalLength();
   int intLen = textLen - decSize - (prefixLen + suffixLen);
   int pos = lineEdit()->cursorPosition() - prefixLen;
 
@@ -133,8 +147,7 @@ ContextAwareSpinBox::stepToCursor(qreal step) const
   int prefixLen = static_cast<int>(prefix().size());
   int suffixLen = static_cast<int>(suffix().size());
   int textLen = static_cast<int>(lineEdit()->text().length());
-  int dec = decimals();
-  int decSize = dec > 0 ? dec + 1 : 0;
+  int decSize = decimalLength();
   int intLen = textLen - decSize - (prefixLen + suffixLen);
 
   // 1387.01 --> LEN = 7, DECIMALS = 2
@@ -187,8 +200,7 @@ ContextAwareSpinBox::onCursorPositionChanged(int oldPos, int newPos)
   int prefixLen = static_cast<int>(prefix().size());
   int suffixLen = static_cast<int>(suffix().size());
   int textLen = static_cast<int>(lineEdit()->text().length());
-  int dec = decimals();
-  int decSize = dec > 0 ? dec + 1 : 0;
+  int decSize = decimalLength();
   int intLen = textLen - decSize - (prefixLen + suffixLen);
   int pos = lineEdit()->cursorPosition() - prefixLen;
 

--- a/ContextAwareSpinBox.cpp
+++ b/ContextAwareSpinBox.cpp
@@ -204,6 +204,10 @@ ContextAwareSpinBox::onCursorPositionChanged(int oldPos, int newPos)
   int intLen = textLen - decSize - (prefixLen + suffixLen);
   int pos = lineEdit()->cursorPosition() - prefixLen;
 
+  // don't interfere with text selection, since setCursorPosition breaks it
+  if (lineEdit()->hasSelectedText())
+    return;
+
   if (pos == intLen + 1) {
     if (oldPos < newPos) // Moving forward
       lineEdit()->setCursorPosition(prefixLen + pos + 1);

--- a/ContextAwareSpinBox.h
+++ b/ContextAwareSpinBox.h
@@ -31,6 +31,7 @@ class ContextAwareSpinBox : public QDoubleSpinBox
 
   using QDoubleSpinBox::QDoubleSpinBox;
   int stepToCursor(qreal) const;
+  int decimalLength() const;
 
 public:
   ContextAwareSpinBox(QWidget *parent = nullptr);

--- a/ContextAwareSpinBox.h
+++ b/ContextAwareSpinBox.h
@@ -46,9 +46,6 @@ public:
   void setMinimumStep();
   void setBlockEnabled(bool);
   bool blockEnabled() const;
-
-public slots:
-  void onCursorPositionChanged(int, int);
 };
 
 #endif // CONTEXTAWARESPINBOX_H


### PR DESCRIPTION
- Fix selecting ranges of digits crossing the decimal point
- Restore normal behaviour of only selecting the decimal portion without the decimal point on a double click
- Fix selecting the whole number through a triple click
- Handle digits being deleted from decimal portion of line edit